### PR TITLE
Fix JAX >= 0.5 compatibility: replace jnp.iscomplexobj(dtype)

### DIFF
--- a/src/spbessax/functions.py
+++ b/src/spbessax/functions.py
@@ -121,9 +121,9 @@ def create_j_l(order: int,
         order_1 = _j_1(r)
 
         derivative_0 = jnp.vectorize(jax.grad(_j_0,
-                                    holomorphic=jnp.iscomplexobj(dtype)))(r)
+                                    holomorphic=onp.issubdtype(dtype, onp.complexfloating)))(r)
         derivative_1 = jnp.vectorize(jax.grad(_j_1,
-                                    holomorphic=jnp.iscomplexobj(dtype)))(r)
+                                    holomorphic=onp.issubdtype(dtype, onp.complexfloating)))(r)
 
         init = (order_0, order_1, 0)
         def loop_orders(carry, x):


### PR DESCRIPTION
`jnp.iscomplexobj()` no longer accepts type objects in JAX >= 0.5, causing a `TypeError` when `create_j_l()` is called with `order >= 2`.

Replaced with `numpy.issubdtype(dtype, numpy.complexfloating)`, which produces identical results for all dtypes.